### PR TITLE
no-top-level-await: Check if we are at the top-level using a depth counter

### DIFF
--- a/lib/rules/no-top-level-await.js
+++ b/lib/rules/no-top-level-await.js
@@ -20,18 +20,16 @@ module.exports = {
         type: "problem",
     },
     create(context) {
-        let inFunction = null
+        let functionDepth = 0
         return {
-            ":function"(node) {
-                inFunction = node
+            ":function"() {
+                functionDepth++
             },
-            ":function:exit"(node) {
-                if (inFunction === node) {
-                    inFunction = null
-                }
+            ":function:exit"() {
+                functionDepth--
             },
             "AwaitExpression, ForOfStatement[await=true]"(node) {
-                if (inFunction) {
+                if (functionDepth > 0) {
                     // not top-level
                     return
                 }

--- a/tests/lib/rules/no-top-level-await.js
+++ b/tests/lib/rules/no-top-level-await.js
@@ -28,6 +28,7 @@ new RuleTester({
         "async function f() { for await (var a of b); }",
         "async function f() { for await (let a of b); }",
         "async function f() { for await (const a of b); }",
+        "async function f() { function g() {}; await expr; }",
         "function f() { async function f() { await expr } }",
     ],
     invalid: [


### PR DESCRIPTION
Fixes #30
